### PR TITLE
[codex] Simplify the home layout

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -291,6 +291,23 @@ button {
     justify-content: flex-end;
 }
 
+.diagnostics-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    cursor: pointer;
+    list-style: none;
+}
+
+.diagnostics-summary::-webkit-details-marker {
+    display: none;
+}
+
+.diagnostics-content {
+    margin-top: 18px;
+}
+
 .button-row,
 .motion-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -609,6 +626,10 @@ button {
     padding-bottom: 0;
 }
 
+.facts-compact {
+    margin-top: 16px;
+}
+
 .facts dt {
     color: var(--muted);
     font-size: 0.84rem;
@@ -804,7 +825,8 @@ button {
     }
 
     .panel-head,
-    .toast {
+    .toast,
+    .diagnostics-summary {
         flex-direction: column;
         align-items: stretch;
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -76,15 +76,7 @@ button {
     padding: 32px 0 48px;
 }
 
-.hero-panel {
-    display: grid;
-    grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.9fr);
-    gap: 24px;
-    margin-bottom: 24px;
-}
-
-.hero-copy,
-.hero-metric,
+.top-strip,
 .panel,
 .toast {
     border: 1px solid var(--panel-border);
@@ -93,21 +85,26 @@ button {
     box-shadow: var(--shadow);
 }
 
-.hero-copy {
-    border-radius: 32px;
-    padding: 32px;
-    position: relative;
-    overflow: hidden;
+.top-strip {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    border-radius: 28px;
+    padding: 24px 28px;
+    margin-bottom: 18px;
 }
 
-.hero-copy::after {
-    content: '';
-    position: absolute;
-    inset: auto -40px -50px auto;
-    width: 220px;
-    height: 220px;
-    border-radius: 50%;
-    background: radial-gradient(circle, rgba(57, 185, 132, 0.28), transparent 72%);
+.top-strip-copy {
+    max-width: 620px;
+}
+
+.top-strip-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 .eyebrow,
@@ -121,30 +118,24 @@ button {
     margin: 0 0 12px;
 }
 
-.hero-copy h1 {
+.top-strip h1 {
     margin: 0;
-    max-width: 12ch;
-    font-size: clamp(2.8rem, 5vw, 4.8rem);
-    line-height: 0.95;
+    font-size: clamp(2.2rem, 4vw, 3.4rem);
+    line-height: 0.98;
 }
 
 .lede {
-    margin: 20px 0 0;
-    max-width: 56ch;
+    margin: 10px 0 0;
+    max-width: 48ch;
     color: var(--muted);
-    font-size: 1.02rem;
-    line-height: 1.75;
+    font-size: 0.98rem;
+    line-height: 1.6;
 }
 
 .hero-badges {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px;
-    margin-top: 24px;
-}
-
-.hero-actions {
-    margin-top: 24px;
+    gap: 10px;
 }
 
 .badge,
@@ -186,23 +177,15 @@ button {
     color: #1f6e87;
 }
 
-.hero-metric {
-    border-radius: 32px;
-    padding: 28px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-}
-
 .metric-value-row {
     display: flex;
     align-items: baseline;
     gap: 8px;
-    margin: 10px 0 18px;
+    margin: 6px 0 16px;
 }
 
 .metric-value {
-    font-size: clamp(3.4rem, 7vw, 5rem);
+    font-size: clamp(3rem, 6vw, 4.2rem);
     line-height: 1;
     font-weight: 800;
 }
@@ -253,26 +236,27 @@ button {
     gap: 18px;
 }
 
+.dashboard-grid-priority {
+    margin-bottom: 18px;
+}
+
 .panel {
     border-radius: 28px;
     padding: 24px;
     grid-column: span 4;
 }
 
-.panel-strong {
-    background: var(--panel-strong);
-    color: #f0f7f2;
-}
-
-.panel-strong .panel-kicker,
-.panel-strong .panel-body,
-.panel-strong .check-list,
-.panel-strong h2 {
-    color: inherit;
-}
-
 .panel-wide {
     grid-column: span 8;
+}
+
+.panel-metric {
+    grid-column: span 5;
+}
+
+.panel-connection,
+.panel-motion {
+    grid-column: span 3;
 }
 
 .panel-head {
@@ -413,39 +397,14 @@ button {
     outline-offset: 3px;
 }
 
-.check-list,
 .facts {
     margin: 18px 0 0;
     padding: 0;
 }
 
-.check-list {
-    list-style: none;
-    display: grid;
-    gap: 10px;
-}
-
-.check-list li {
-    padding: 10px 12px;
-    border-radius: 14px;
-    background: rgba(255, 255, 255, 0.08);
-}
-
-.check-list li.ok {
-    color: #a8f0c8;
-}
-
-.check-list li.warn {
-    color: #ffd696;
-}
-
-.check-list li.neutral {
-    color: rgba(240, 247, 242, 0.8);
-}
-
 .control {
-    min-height: 160px;
-    padding: 20px;
+    min-height: 148px;
+    padding: 18px;
     text-align: left;
     color: white;
     cursor: pointer;
@@ -518,6 +477,13 @@ button {
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--muted);
+}
+
+.support-note {
+    margin: 14px 0 0;
+    color: var(--muted);
+    font-size: 0.88rem;
+    line-height: 1.55;
 }
 
 .history-list {
@@ -805,12 +771,16 @@ button {
 }
 
 @media (max-width: 980px) {
-    .hero-panel {
-        grid-template-columns: 1fr;
+    .top-strip {
+        flex-direction: column;
+        align-items: stretch;
     }
 
     .panel,
-    .panel-wide {
+    .panel-wide,
+    .panel-metric,
+    .panel-connection,
+    .panel-motion {
         grid-column: span 12;
     }
 }
@@ -821,8 +791,7 @@ button {
         padding-top: 12px;
     }
 
-    .hero-copy,
-    .hero-metric,
+    .top-strip,
     .panel {
         border-radius: 24px;
         padding: 20px;

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -198,7 +198,6 @@ export class FlexiSpotApp {
         const heightPercentage = this.state.currentHeight === null
             ? 0
             : clamp(((this.state.currentHeight - HEIGHT_MIN) / (HEIGHT_MAX - HEIGHT_MIN)) * 100, 0, 100);
-        const recentChart = this.renderSessionChart();
         const chart = this.renderDailyChart();
         const supportMessage = this.getSupportMessage(supported, secure);
 
@@ -302,40 +301,8 @@ export class FlexiSpotApp {
                     <article class="panel panel-wide">
                         <div class="panel-head">
                             <div>
-                                <p class="panel-kicker">Live Timeline</p>
-                                <h2>Session Height Flow</h2>
-                            </div>
-                            <p class="shortcut-hint">${recentChart.sampleCount} samples / 1 sec</p>
-                        </div>
-                        <div class="chart-card">
-                            ${recentChart.svg}
-                            <div class="chart-footer">
-                                <span>${recentChart.startLabel}</span>
-                                <span>${recentChart.middleLabel}</span>
-                                <span>${recentChart.endLabel}</span>
-                            </div>
-                        </div>
-                        <div class="chart-stats">
-                            <div>
-                                <dt>Min</dt>
-                                <dd>${recentChart.minLabel}</dd>
-                            </div>
-                            <div>
-                                <dt>Max</dt>
-                                <dd>${recentChart.maxLabel}</dd>
-                            </div>
-                            <div>
-                                <dt>Duration</dt>
-                                <dd>${recentChart.durationLabel}</dd>
-                            </div>
-                        </div>
-                    </article>
-
-                    <article class="panel panel-wide">
-                        <div class="panel-head">
-                            <div>
                                 <p class="panel-kicker">Timeline</p>
-                                <h2>Daily Height Map</h2>
+                                <h2>Today</h2>
                             </div>
                             <p class="shortcut-hint">${chart.sampleCount} samples today</p>
                         </div>
@@ -395,35 +362,40 @@ export class FlexiSpotApp {
                     </article>
 
                     <article class="panel panel-wide">
-                        <div class="panel-head">
-                            <div>
-                                <p class="panel-kicker">Diagnostics</p>
-                                <h2>Serial RX Monitor</h2>
+                        <details class="diagnostics-panel">
+                            <summary class="diagnostics-summary">
+                                <div>
+                                    <p class="panel-kicker">Diagnostics</p>
+                                    <h2>Serial RX Monitor</h2>
+                                </div>
+                                <span class="shortcut-hint">${String(this.state.receivedChunkCount)} chunks / ${String(this.state.receivedByteCount)} bytes</span>
+                            </summary>
+                            <div class="diagnostics-content">
+                                <div class="actions-inline">
+                                    <button class="button ghost small" data-action="wake" aria-label="Send wake command" ${this.state.isConnected ? '' : 'disabled'}>Send Wake</button>
+                                    <button class="button ghost small" data-action="pause" aria-pressed="${this.state.capturePaused ? 'true' : 'false'}">${this.state.capturePaused ? 'Resume' : 'Pause'}</button>
+                                    <button class="button ghost small" data-action="copy" aria-label="Copy captured serial data" ${this.state.rawCapture.length > 0 ? '' : 'disabled'}>Copy</button>
+                                    <button class="button ghost small" data-action="clear" aria-label="Clear captured serial data">Clear</button>
+                                </div>
+                                <dl class="facts facts-compact">
+                                    <div>
+                                        <dt>RX Chunks</dt>
+                                        <dd>${String(this.state.receivedChunkCount)}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>RX Bytes</dt>
+                                        <dd>${String(this.state.receivedByteCount)}</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Decode State</dt>
+                                        <dd>${this.state.currentHeight === null ? 'No parsed height yet' : 'Height parsed'}</dd>
+                                    </div>
+                                </dl>
+                                <div class="raw-log" role="log" aria-live="polite" aria-label="Serial receive log">
+                                    ${this.renderRawPreview()}
+                                </div>
                             </div>
-                            <div class="actions-inline">
-                                <button class="button ghost small" data-action="wake" aria-label="Send wake command" ${this.state.isConnected ? '' : 'disabled'}>Send Wake</button>
-                                <button class="button ghost small" data-action="pause" aria-pressed="${this.state.capturePaused ? 'true' : 'false'}">${this.state.capturePaused ? 'Resume' : 'Pause'}</button>
-                                <button class="button ghost small" data-action="copy" aria-label="Copy captured serial data" ${this.state.rawCapture.length > 0 ? '' : 'disabled'}>Copy</button>
-                                <button class="button ghost small" data-action="clear" aria-label="Clear captured serial data">Clear</button>
-                            </div>
-                        </div>
-                        <dl class="facts">
-                            <div>
-                                <dt>RX Chunks</dt>
-                                <dd>${String(this.state.receivedChunkCount)}</dd>
-                            </div>
-                            <div>
-                                <dt>RX Bytes</dt>
-                                <dd>${String(this.state.receivedByteCount)}</dd>
-                            </div>
-                            <div>
-                                <dt>Decode State</dt>
-                                <dd>${this.state.currentHeight === null ? 'No parsed height yet' : 'Height parsed'}</dd>
-                            </div>
-                        </dl>
-                        <div class="raw-log" role="log" aria-live="polite" aria-label="Serial receive log">
-                            ${this.renderRawPreview()}
-                        </div>
+                        </details>
                     </article>
                 </section>
 

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -200,26 +200,27 @@ export class FlexiSpotApp {
             : clamp(((this.state.currentHeight - HEIGHT_MIN) / (HEIGHT_MAX - HEIGHT_MIN)) * 100, 0, 100);
         const recentChart = this.renderSessionChart();
         const chart = this.renderDailyChart();
+        const supportMessage = this.getSupportMessage(supported, secure);
 
         this.root.innerHTML = `
             <div class="shell">
-                <section class="hero-panel">
-                    <div class="hero-copy">
-                        <p class="eyebrow">FlexiSpot Control Deck</p>
-                        <h1>Hardware control UI rebuilt for the browser.</h1>
-                        <p class="lede">
-                            スマートホームと IoT ダッシュボードの情報設計を取り入れ、接続状態、姿勢切り替え、リアルタイム高さ確認を一画面で完結させます。
-                        </p>
+                <section class="top-strip">
+                    <div class="top-strip-copy">
+                        <p class="eyebrow">FlexiSpot Controller</p>
+                        <h1>Connect and move.</h1>
+                        <p class="lede">ブラウザから昇降デスクを接続して、そのまま操作します。</p>
+                    </div>
+                    <div class="top-strip-actions">
                         <div class="hero-badges">
-                            <span class="badge ${supported ? 'ok' : 'warn'}">${supported ? 'Web Serial Ready' : 'Browser Unsupported'}</span>
-                            <span class="badge ${secure ? 'ok' : 'warn'}">${secure ? 'Secure Context' : 'HTTPS Required'}</span>
+                            <span class="badge ${this.statusTone(this.state.connectionStatus)}">${this.statusLabel(this.state.connectionStatus)}</span>
                             <span class="badge neutral">v${APP_VERSION}</span>
                         </div>
-                        <div class="hero-actions">
-                            <button class="button ghost" data-action="open-settings">Settings</button>
-                        </div>
+                        <button class="button ghost" data-action="open-settings">Settings</button>
                     </div>
-                    <div class="hero-metric">
+                </section>
+
+                <section class="dashboard-grid dashboard-grid-priority">
+                    <article class="panel panel-metric">
                         <p class="metric-label">Current Height</p>
                         <div class="metric-value-row">
                             <span class="metric-value">${this.state.currentHeight?.toFixed(1) ?? '--'}</span>
@@ -233,37 +234,28 @@ export class FlexiSpotApp {
                             <span>${HEIGHT_MAX} cm</span>
                         </div>
                         <p class="metric-caption">${this.formatHeightStatus()}</p>
-                    </div>
-                </section>
+                    </article>
 
-                <section class="dashboard-grid">
-                    <article class="panel panel-strong">
+                    <article class="panel panel-connection">
                         <div class="panel-head">
                             <div>
                                 <p class="panel-kicker">Connection</p>
                                 <h2>Desk Link</h2>
                             </div>
-                            <span class="status-pill ${this.statusTone(this.state.connectionStatus)}">
-                                ${this.statusLabel(this.state.connectionStatus)}
-                            </span>
                         </div>
                         <p class="panel-body" role="status" aria-live="polite">${this.escapeHtml(this.state.statusMessage)}</p>
                         <div class="button-row">
                             <button class="button primary" data-action="connect" aria-label="Connect to desk" ${!supported || !secure || this.state.isConnected ? 'disabled' : ''}>Connect</button>
                             <button class="button secondary" data-action="disconnect" aria-label="Disconnect from desk" ${this.state.isConnected ? '' : 'disabled'}>Disconnect</button>
                         </div>
-                        <ul class="check-list">
-                            <li class="${supported ? 'ok' : 'warn'}">Chrome / Edge 系ブラウザ</li>
-                            <li class="${secure ? 'ok' : 'warn'}">HTTPS または localhost</li>
-                            <li class="${this.state.isConnected ? 'ok' : 'neutral'}">ユーザーがシリアルポートを許可</li>
-                        </ul>
+                        ${supportMessage ? `<p class="support-note">${this.escapeHtml(supportMessage)}</p>` : ''}
                     </article>
 
-                    <article class="panel">
+                    <article class="panel panel-motion">
                         <div class="panel-head">
                             <div>
                                 <p class="panel-kicker">Manual Control</p>
-                                <h2>Live Motion</h2>
+                                <h2>Move</h2>
                             </div>
                             <p class="shortcut-hint">Arrow Up / Arrow Down</p>
                         </div>
@@ -277,14 +269,15 @@ export class FlexiSpotApp {
                                 <strong>DOWN</strong>
                             </button>
                         </div>
-                        <p class="muted">押している間だけコマンドを継続送信します。離した時点で停止します。</p>
                     </article>
+                </section>
 
+                <section class="dashboard-grid">
                     <article class="panel panel-wide">
                         <div class="panel-head">
                             <div>
                                 <p class="panel-kicker">Quick Scenes</p>
-                                <h2>Preset Deck</h2>
+                                <h2>Presets</h2>
                             </div>
                             <button class="button ghost" data-action="customize" aria-haspopup="dialog" aria-expanded="${this.state.isPresetEditorOpen ? 'true' : 'false'}">Labels</button>
                         </div>
@@ -1207,6 +1200,22 @@ export class FlexiSpotApp {
 
         if (this.state.settingsOpen) {
             return document.getElementById(SETTINGS_MODAL_ID);
+        }
+
+        return null;
+    }
+
+    private getSupportMessage(supported: boolean, secure: boolean): string | null {
+        if (!supported) {
+            return 'Chrome / Edge 系ブラウザで開いてください。';
+        }
+
+        if (!secure) {
+            return 'HTTPS または localhost で開いてください。';
+        }
+
+        if (!this.state.isConnected) {
+            return '接続すると操作と高さ表示が有効になります。';
         }
 
         return null;


### PR DESCRIPTION
## What changed
- replace the oversized hero with a compact top strip
- move the main focus to height, connection, and manual controls
- remove always-visible support checklist noise and collapse it into a single short support note
- simplify section labels so the first screen reads more like a controller than a dashboard

## Why
The first view was carrying too much explanatory and duplicated status information, which made the actual desk controls feel secondary. The page works better when the primary action path is obvious immediately.

## Impact
- the top of the page is more compact and easier to scan
- the most important actions are now visually prioritized
- compatibility/setup messaging is still available, but no longer dominates the default view

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`